### PR TITLE
Fixed Replace button clickthrough URL, again

### DIFF
--- a/views/power_battery_condition_widget.php
+++ b/views/power_battery_condition_widget.php
@@ -29,7 +29,7 @@ $(document).on('appReady appUpdate', function(e, lang) {
 		
 		// Set statuses
 		if(data.now){
-			panel.append(' <a href="'+baseUrl+'#replace" class="btn btn-danger"><span class="bigger-150">'+data.now+'</span><br>'+i18n.t('power.widget.now')+'</a>');
+			panel.append(' <a href="'+baseUrl+'#now" class="btn btn-danger"><span class="bigger-150">'+data.now+'</span><br>'+i18n.t('power.widget.now')+'</a>');
 		}
 		if(data.service){
 			panel.append(' <a href="'+baseUrl+'#service" class="btn btn-danger"><span class="bigger-150">'+data.service+'</span><br>'+i18n.t('power.widget.service')+'</a>');


### PR DESCRIPTION
#now is a better choice than #replace which actually pulls in results for Replace Now and Replace Soon.