### PR TITLE
Workaround sets ManufactureDate to 'null'

### DIFF
--- a/power_model.php
+++ b/power_model.php
@@ -340,11 +340,17 @@ class Power_model extends \Model
 
             $ManufactureDate = $this->manufacture_date;
 
-            $mfgday = $this->manufacture_date & 31;
-            $mfgmonth = ($this->manufacture_date >> 5) & 15;
-            $mfgyear = (($this->manufacture_date >> 9) & 127) + 1980;
+            if (is_numeric($this->manufacture_date)) {
+                $mfgday = $this->manufacture_date & 31;
+                $mfgmonth = ($this->manufacture_date >> 5) & 15;
+                $mfgyear = (($this->manufacture_date >> 9) & 127) + 1980;
 
-            $this->manufacture_date = sprintf("%d-%02d-%02d", $mfgyear, $mfgmonth, $mfgday);
+                $this->manufacture_date = sprintf("%d-%02d-%02d", $mfgyear, $mfgmonth, $mfgday);
+             } else {
+                // Hardcode the date to be 'null' for the time being until
+                //   data from BigSur can be evaluated correctly. 
+                $this->manufacture_date = null;
+            }
         }
 
         // Timestamp added by the server


### PR DESCRIPTION
Big Sur changed how the Manufacture Date is presented for the battery.  This PR provides a temporary workaround to set non-numeric script results to 'null' until a fix can be made.